### PR TITLE
Bug: NameHelper.CreateNameFromCallerArgumentExpression stops scanning too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] - 2026-03-07
+
+### Fixed
+- NameHelper.CreateNameFromCallerArgumentExpression stops scanning too early (Fixes [issue #7](https://github.com/rent-a-developer/DbConnectionPlus/issues/7))
+
 ## [1.2.0] - 2026-02-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/RentADeveloper.DbConnectionPlus)](https://www.nuget.org/packages/RentADeveloper.DbConnectionPlus/)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rent-a-developer_DbConnectionPlus&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rent-a-developer_DbConnectionPlus)
 [![license](https://img.shields.io/badge/License-MIT-purple.svg)](LICENSE.md)
-![semver](https://img.shields.io/badge/semver-1.2.0-blue)
+![semver](https://img.shields.io/badge/semver-1.2.1-blue)
 
 # ![image icon](https://raw.githubusercontent.com/rent-a-developer/DbConnectionPlus/main/icon.png) DbConnectionPlus
 A lightweight .NET ORM and extension library for the type

--- a/src/DbConnectionPlus/DbConnectionPlus.csproj
+++ b/src/DbConnectionPlus/DbConnectionPlus.csproj
@@ -21,7 +21,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Version>1.2.0</Version>
+		<Version>1.2.1</Version>
 		<PackageReleaseNotes>See CHANGELOG.md.</PackageReleaseNotes>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/DbConnectionPlus/Helpers/NameHelper.cs
+++ b/src/DbConnectionPlus/Helpers/NameHelper.cs
@@ -26,7 +26,7 @@ internal static class NameHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static String CreateNameFromCallerArgumentExpression(ReadOnlySpan<Char> expression, Int32 maximumLength)
     {
-        // Remove common prefixes that are not relevant for the name.
+        // Remove common prefixes:
 
         if (expression.StartsWith("this.", StringComparison.Ordinal))
         {
@@ -43,18 +43,18 @@ internal static class NameHelper
             expression = expression[3..];
         }
 
-        var scanLength = Math.Min(expression.Length, maximumLength);
+        var bufferLength = Math.Min(expression.Length, maximumLength);
 
-        var buffer = scanLength <= 512 ? stackalloc Char[scanLength] : new Char[scanLength];
+        var buffer = bufferLength <= 512 ? stackalloc Char[bufferLength] : new Char[bufferLength];
 
-        ref var src = ref MemoryMarshal.GetReference(expression);
-        ref var dst = ref MemoryMarshal.GetReference(buffer);
+        ref var expressionPointer = ref MemoryMarshal.GetReference(expression);
+        ref var bufferPointer = ref MemoryMarshal.GetReference(buffer);
 
         var count = 0;
 
-        for (var i = 0; i < scanLength; i++)
+        for (var i = 0; i < expression.Length; i++)
         {
-            var character = Unsafe.Add(ref src, i);
+            var character = Unsafe.Add(ref expressionPointer, i);
 
             if (
                 (UInt32)(character - '0') <= 9 || // Digits
@@ -63,11 +63,16 @@ internal static class NameHelper
                 character == '_'
             )
             {
-                Unsafe.Add(ref dst, count++) = character;
+                Unsafe.Add(ref bufferPointer, count++) = character;
+
+                if (count == maximumLength)
+                {
+                    break;
+                }
             }
         }
 
-        // Convert the first character to uppercase if it is a lowercase letter.
+        // Convert the first character to uppercase if necessary.
         if (count != 0 && (UInt32)(buffer[0] - 'a') <= 25)
         {
             buffer[0] = (Char)(buffer[0] - 32);

--- a/tests/DbConnectionPlus.UnitTests/Helpers/NameHelperTests.cs
+++ b/tests/DbConnectionPlus.UnitTests/Helpers/NameHelperTests.cs
@@ -16,6 +16,8 @@ public class NameHelperTests : UnitTestsBase
     [InlineData("[productId]", 10, "ProductId")]
     [InlineData("entityIds.Where(a => a > 5).ToArray()[0]", 60, "EntityIdsWhereaa5ToArray0")]
     [InlineData("", 10, "")]
+    [InlineData("..........1234567890", 10, "1234567890")]
+    [InlineData(".....12345.....67890", 10, "1234567890")]
     public void CreateNameFromCallerArgumentExpression_ShouldCreateName(
         String expression,
         Int32 maximumLength,


### PR DESCRIPTION
Fixes [Issue  #7](https://github.com/rent-a-developer/DbConnectionPlus/issues/7)